### PR TITLE
deps: Update `dependency-graph` to `^1.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@11ty/eleventy-utils": "^1.0.2",
     "acorn": "^8.10.0",
-    "dependency-graph": "^0.11.0",
+    "dependency-graph": "^1.0.0",
     "normalize-path": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`dependency-graph` was at `0.11.0` (published 2021-03-05).

This updates it to `1.0.0` (published 2023-12-06).