### PR TITLE
Ignore import assertions (e.g., CSS and JSON modules)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@11ty/eleventy-utils": "^1.0.2",
     "acorn": "^8.10.0",
+    "acorn-import-assertions": "^1.9.0",
     "dependency-graph": "^1.0.0",
     "normalize-path": "^3.0.0"
   },


### PR DESCRIPTION
Adds the `acorn-import-assertions` plugin to allow JSON and CSS (etc.) modules to be parsed correctly. Currently ignores these files, but happy to take a different tack if you'd rather the system just skip recursion on them instead.

Fixes #2 